### PR TITLE
Disable probe offset for bed leveling

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1704,7 +1704,7 @@
  *     |    [-]    |
  *     O-- FRONT --+
  */
-#define NOZZLE_TO_PROBE_OFFSET {-28.5, 22, 0 }
+//#define NOZZLE_TO_PROBE_OFFSET {-28.5, 22, 0 }
 
 // Enable and set to use a specific tool for probing. Disable to allow any tool.
 #define PROBING_TOOL 0


### PR DESCRIPTION
The default configuration of the Neptune 3 uses the nozzle as the bed probe.

NOZZLE_TO_PROBE_OFFSET causes the bed mesh to be off-center and correspondingly inaccurate.