### PR TITLE
change Multifile_flag to false when printer is neptune_3_pro

### DIFF
--- a/Marlin/src/lcd/extui/dgus/elegoo/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/dgus/elegoo/DGUSDisplayDef.cpp
@@ -201,7 +201,12 @@
   static int16_t max_top           = 0;
   static int16_t old_top_file      = 0; //< file on top of file chooser
   static int16_t file_to_print     = 0; //< touched file to be confirmed
-  bool Multifile_flag  = true;
+  
+  #ifdef NEPTUNE_3_PRO
+    bool Multifile_flag = false;
+  #else
+    bool Multifile_flag  = true;
+  #endif
 
   void RTS_reset_settings(void) 
   {


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Fix issue #6 where the sd card screen is not shown on neptune 3 pro

It all came down to a change where the Multifile_flag was set to true on start. For n3p this has to be set as false

### Requirements

N/A

### Benefits

Ability to use sd card on N3Pro

### Configurations

N/A

### Related Issues

#6 
